### PR TITLE
Add todoist_get_projects tool to resolve #2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,21 @@ const GET_TASKS_TOOL: Tool = {
   }
 };
 
+const GET_PROJECTS_TOOL: Tool = {
+  name: "todoist_get_projects",
+  description: "Get a list of all projects with their IDs and names for use in other tools",
+  inputSchema: {
+    type: "object",
+    properties: {
+      limit: {
+        type: "number",
+        description: "Maximum number of projects to return (optional, default: 50)",
+        default: 50
+      }
+    }
+  }
+};
+
 const UPDATE_TASK_TOOL: Tool = {
   name: "todoist_update_task",
   description: "Update an existing task in Todoist by searching for it by name and then updating it",
@@ -178,6 +193,15 @@ function isGetTasksArgs(args: unknown): args is {
   );
 }
 
+function isGetProjectsArgs(args: unknown): args is {
+  limit?: number;
+} {
+  return (
+    typeof args === "object" &&
+    args !== null
+  );
+}
+
 function isUpdateTaskArgs(args: unknown): args is {
   task_name: string;
   content?: string;
@@ -217,7 +241,7 @@ function isCompleteTaskArgs(args: unknown): args is {
 
 // Tool handlers
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [CREATE_TASK_TOOL, GET_TASKS_TOOL, UPDATE_TASK_TOOL, DELETE_TASK_TOOL, COMPLETE_TASK_TOOL],
+  tools: [CREATE_TASK_TOOL, GET_TASKS_TOOL, GET_PROJECTS_TOOL, UPDATE_TASK_TOOL, DELETE_TASK_TOOL, COMPLETE_TASK_TOOL],
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -282,6 +306,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [{ 
           type: "text", 
           text: filteredTasks.length > 0 ? taskList : "No tasks found matching the criteria" 
+        }],
+        isError: false,
+      };
+    }
+
+    if (name === "todoist_get_projects") {
+      if (!isGetProjectsArgs(args)) {
+        throw new Error("Invalid arguments for todoist_get_projects");
+      }
+
+      const projects = await todoistClient.getProjects();
+      
+      // Apply limit if provided
+      let limitedProjects = projects;
+      if (args.limit && args.limit > 0) {
+        limitedProjects = projects.slice(0, args.limit);
+      }
+      
+      const projectList = limitedProjects.map(project => 
+        `- ${project.name} (ID: ${project.id})`
+      ).join('\n');
+      
+      return {
+        content: [{ 
+          type: "text", 
+          text: limitedProjects.length > 0 ? `Projects:\n${projectList}` : "No projects found" 
         }],
         isError: false,
       };


### PR DESCRIPTION
## Summary
This PR adds a new `todoist_get_projects` tool to the MCP server that allows users to retrieve a list of all Todoist projects with their names and IDs.

## Changes
- ✅ Added `GET_PROJECTS_TOOL` constant with proper schema definition
- ✅ Added `isGetProjectsArgs` type guard for argument validation
- ✅ Implemented `todoist_get_projects` handler in the CallToolRequestSchema
- ✅ Updated the tools array in ListToolsRequestSchema to include the new tool
- ✅ Added optional `limit` parameter to control number of projects returned (default: 50)

## API Usage
```javascript
// Get all projects
mcp_todoist_get_projects()

// Get limited number of projects
mcp_todoist_get_projects({ limit: 10 })
```

## Output Format
Returns a formatted list showing project names and their corresponding IDs:
```
Projects:
- 👱🏻‍♂️Me (ID: 2164545108)
- Inbox (ID: 2164544999)
- 👨🏻‍💼Adulting (ID: 2204961989)
...
```

## Resolves
Closes #2

## Testing
The implementation follows the same patterns as existing tools in the codebase and uses the official Todoist API client's `getProjects()` method.